### PR TITLE
fix(auth): extend access and refresh token expiration to 1 hour

### DIFF
--- a/src/application/uses-cases/auth/login-user.ts
+++ b/src/application/uses-cases/auth/login-user.ts
@@ -39,7 +39,7 @@ export class LoginUser {
     };
 
     // Generar access token (corta duración)
-    const accessToken = await new JwtTokenGenerator().generate(tokenPayload, '15m');
+    const accessToken = await new JwtTokenGenerator().generate(tokenPayload, '1h');
 
     // Generar refresh token (larga duración)
     const refreshTokenGenerator = new JwtRefreshToken();
@@ -59,7 +59,7 @@ export class LoginUser {
       },
       token: accessToken,
       refreshToken,
-      expiresIn: 15 * 60, // 15 minutos en segundos
+      expiresIn: 60 * 60, // 1 hora en segundos
     } as AuthUser;
   }
 }

--- a/src/application/uses-cases/auth/refresh-token.ts
+++ b/src/application/uses-cases/auth/refresh-token.ts
@@ -31,7 +31,7 @@ export class RefreshTokenUseCase {
       };
 
       // 4. Generar nuevo access token (corta duración)
-      const newAccessToken = await this.generateToken.generate(accessTokenPayload, '15m');
+      const newAccessToken = await this.generateToken.generate(accessTokenPayload, '1h');
 
       if (!newAccessToken) {
         throw AppError.internalError('Failed to generate access token');
@@ -48,7 +48,7 @@ export class RefreshTokenUseCase {
       return {
         accessToken: newAccessToken,
         refreshToken: newRefreshToken,
-        expiresIn: 15 * 60, // 15 minutos en segundos
+        expiresIn: 60 * 60, // 1 hora en segundos
       };
     } catch (error) {
       if (error instanceof AppError) {


### PR DESCRIPTION
This pull request updates the authentication token expiration policy to extend the access token lifetime from 15 minutes to 1 hour. The changes ensure both the issued access tokens and the values returned in authentication responses are consistent with the new duration.

Token expiration updates:

* Updated the access token expiration in the `LoginUser` use case to 1 hour instead of 15 minutes, and adjusted the `expiresIn` value in the returned `AuthUser` object to match. [[1]](diffhunk://#diff-c3c45e5c27faf3adadd2655cb159223ad536d66f294f4d80d8397d9cce3f43ebL42-R42) [[2]](diffhunk://#diff-c3c45e5c27faf3adadd2655cb159223ad536d66f294f4d80d8397d9cce3f43ebL62-R62)
* Updated the access token expiration in the `RefreshTokenUseCase` to 1 hour, and set the corresponding `expiresIn` value in the refresh response to 1 hour. [[1]](diffhunk://#diff-09738f9e926a1c93cf186746b2cb5b1b9662ac4c3d38ca1a62021a2c9132ce27L34-R34) [[2]](diffhunk://#diff-09738f9e926a1c93cf186746b2cb5b1b9662ac4c3d38ca1a62021a2c9132ce27L51-R51)