### PR TITLE
Adjust jest config

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -37,10 +37,10 @@ const config: Config = {
 
   // An array of regexp pattern strings used to skip coverage collection
   coveragePathIgnorePatterns: [
-    '\\\\node_modules\\\\',
-    '\\.mock\\.[^\\\\]+$',
-    '\\.test\\.[^\\\\]+$',
-    '\\.spec\\.[^\\\\]+$',
+    '/node_modules/',
+    '\\.mock\\.[^/\\\\]+$',
+    '\\.test\\.[^/\\\\]+$',
+    '\\.spec\\.[^/\\\\]+$',
   ],
 
   // Indicates which provider should be used to instrument code for coverage
@@ -178,7 +178,7 @@ const config: Config = {
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: [
-    '\\\\node_modules\\\\',
+    '/node_modules/',
     '.*\\.integration\\.test\\.[jt]s$', // ✅ Excluir tests de integración de los unitarios
   ],
 

--- a/jest.integration.config.ts
+++ b/jest.integration.config.ts
@@ -12,7 +12,7 @@ const INTEGRATION_CONFIG: Config = {
   ],
   // ✅ Sobrescribir testPathIgnorePatterns para permitir archivos .integration.test.ts
   testPathIgnorePatterns: [
-    '\\\\node_modules\\\\', // Solo ignorar node_modules
+    '/node_modules/', // Solo ignorar node_modules
   ],
   moduleNameMapper: {
     '^@application/(.*)$': '<rootDir>/src/application/$1',


### PR DESCRIPTION
chore: standardize jest regex patterns to use forward slashes for cross-platform compatibility